### PR TITLE
Create Asus-Prime-B550-Plus-nct6798.conf

### DIFF
--- a/B550/ASUS/Asus-Prime-B550-Plus-nct6798.conf
+++ b/B550/ASUS/Asus-Prime-B550-Plus-nct6798.conf
@@ -1,0 +1,49 @@
+# Asus Prime B550 Plus mainboard with Nuvoton NCT6798D multi IO chip
+chip "nct6798-isa-0290"
+
+    # Voltages
+    label in0 "Vcore"
+    compute in0 @*2, @/2
+    label in1 "+5V"
+    compute in1 ((40/10)+1)*@, @/((40/10)+1)
+    label in2 "AVSB"
+    label in3 "3VCC"
+    label in4 "+12V"
+    compute in4 ((110/10)+1)*@, @/((110/10)+1)
+    ignore in5
+    ignore in6
+    label in7 "3VSB"
+    ignore in8 # Some people think it's a "Vbat" but it is NOT. I removed battery to check it myself.
+    label in9 "CPU 1.80V"
+    ignore in10
+    ignore in11
+    ignore in12
+    ignore in13
+    ignore in14
+
+    # Fans
+    label fan1 "CHA_FAN1"
+    label fan2 "CPU_FAN"
+    label fan3 "CHA_FAN2"
+    label fan4 "CHA_FAN3"
+    ignore fan5
+    label fan6 "AIO_PUMP"
+    label fan7 "CPU_OPT"
+
+    # Temperatures as BIOS reports them
+    label temp1 "Motherboard"
+    ignore temp2
+    ignore temp3
+    label temp4 "Chipset"
+    ignore temp5 # external thermistor connected to the T_SENSOR header on MB 
+    ignore temp6
+    label temp7 "CPU"
+    ignore temp8
+    ignore temp9
+    ignore temp10
+    label temp11 "CPU package"
+
+    # Some other things to ignore
+    ignore intrusion0
+    ignore intrusion1
+    ignore beep_enable


### PR DESCRIPTION
Added lm_sensors config file for Asus Prime B550 Plus motherboard with Nuvoton NCT6798D multi IO chip.